### PR TITLE
ci: automate deployment to aws amplify on push and merge to main branch

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,42 @@
+name: Deploy to AWS Amplify
+
+on:
+  push:
+    branches:
+      - main  
+  # Trigger deployment when a PR is merged into main
+  pull_request:
+    branches:
+      - main 
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Install AWS CLI
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+
+      # Step 3: Configure AWS credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2  
+
+      # Step 4: Deploy to AWS Amplify
+      - name: Trigger AWS Amplify deployment
+        run: |
+          aws amplify start-job \
+            --app-id ${{ secrets.AWS_AMPLIFY_APP_ID }} \
+            --branch-name main \
+            --job-type RELEASE

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,11 +1,13 @@
 // frontend/src/services/api.ts
 import type { SearchRequest, SearchResponse } from "../../types/api";
 
+const BASE_URL = "http://18.219.50.112:8000"
+
 export async function searchBooks(query: string): Promise<SearchResponse> {
   console.log(`Searching for books with query: ${query}`);
   const payload: SearchRequest = { query };
 
-  const response = await fetch("http://0.0.0.0:8000/search_books", {
+  const response = await fetch(`${BASE_URL}/search_books`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
- Added GitHub Actions workflow to deploy the frontend to AWS Amplify automatically.
- Workflow triggers deployment on `push` and `pull_request` merges into `main`.
- Ensures that frontend changes are deployed seamlessly without manual intervention.