### PR TITLE
feat(docker): add docker-compose override for local development

### DIFF
--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+
+services:
+  api:
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}  # Use local Redis password
+    volumes:
+      - .:/code  # Mount local code for live updates
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+
+  redis:
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]


### PR DESCRIPTION
- Added `docker-compose.override.yml` to enable local development configurations.
- Mounted local code (`.:/code`) in the `api` container for live updates.
- Configured FastAPI to auto-reload on code changes (`--reload`).
- Passed `REDIS_PASSWORD` from `.env` to allow local Redis authentication.
- Ensured Redis runs with `--requirepass` for local security.