### PR TITLE
fix(cd-pipeline): fix iam permissions to ensure pipeline retrieves se…

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -6,11 +6,6 @@ on:
       - main
     paths:
       - "backend/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "backend/**"
 
 jobs:
   deploy-backend:
@@ -33,19 +28,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-          
       - name: Retrieve Redis Password from AWS Secrets Manager
         run: |
           REDIS_PASSWORD=$(aws secretsmanager get-secret-value \
             --secret-id redis_password \
             --query SecretString \
-            --output text)
+            --output text | jq -r '.')
           echo "REDIS_PASSWORD=$REDIS_PASSWORD" >> $GITHUB_ENV
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build Docker image 
+      - name: Build Docker image
         working-directory: ./backend
         run: |
           docker buildx build \


### PR DESCRIPTION
- Updated GitHub Actions workflow (`deploy-backend.yml`) to ensure `REDIS_PASSWORD` is properly retrieved from AWS Secrets Manager.
- Fixed IAM permissions by granting `secretsmanager:GetSecretValue` to `book-search-web-app-user`.
- Modified AWS CLI command to correctly parse secret values using `jq` to prevent formatting issues.
- Ensured that GitHub Actions sets `REDIS_PASSWORD` in the environment without errors.

This update resolves access issues preventing the ECS deployment pipeline from retrieving secrets during the build process.